### PR TITLE
Create catalog on Apps level instead of Package level.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-Keypirinha WindowsApps
-==========================
+# Keypirinha WindowsApps
 
-This is a package for the fast keystroke launcher keypirinha (http://keypirinha.com/). It lists
+This is a package for the fast keystroke launcher keypirinha (<http://keypirinha.com/>). It lists
 Universal Windows Apps (formerly known as Metro Apps) for launching.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Universal Windows Apps (formerly known as Metro Apps) for launching.
 ## Usage
 
 All items are prefixed with `Windows App:` (configurable).
+Miscellaneous items are hidden by default.
 
 ## Installation
 

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -127,7 +127,7 @@ class AppXPackage(object):
     def _get_resource(install_location, package_id, resource):
         """Helper method to resolve resource strings to their (localized) value
         """
-        # testing slightly better working resolver
+        # testing more compact working resolver
         try:
             if resource[0:12] == RESOURCE_PREFIX:
                 resource_key = resource[12:]
@@ -151,36 +151,36 @@ class AppXPackage(object):
         except OSError:
             pass
 
-        try:
-            resource_descriptor = None
-            if resource.startswith("ms-resource:/"):
-                resource_descriptor = "@{{{}\\resources.pri? {}}}".format(install_location,
-                                                                          resource)
-            elif resource.startswith(RESOURCE_PREFIX):
-                resource_descriptor = "@{{{}\\resources.pri? ms-resource://{}/resources/{}}}".format(install_location,
-                                                                                                     package_id,
-                                                                                                     resource[len(RESOURCE_PREFIX):])
-            if not resource_descriptor:
-                inp = ct.create_unicode_buffer(resource_descriptor)
-                output = ct.create_unicode_buffer(1024)
-                result = SHLoadIndirectString(inp, output, ct.sizeof(output), None)
-                if result == 0 and output.value:
-                    if not output.value.startswith(RESOURCE_PREFIX):
-                        return output.value
-        except OSError:
-            pass
+        # try:
+        #     resource_descriptor = None
+        #     if resource.startswith("ms-resource:/"):
+        #         resource_descriptor = "@{{{}\\resources.pri? {}}}".format(install_location,
+        #                                                                   resource)
+        #     elif resource.startswith(RESOURCE_PREFIX):
+        #         resource_descriptor = "@{{{}\\resources.pri? ms-resource://{}/resources/{}}}".format(install_location,
+        #                                                                                              package_id,
+        #                                                                                              resource[len(RESOURCE_PREFIX):])
+        #     if resource_descriptor:
+        #         inp = ct.create_unicode_buffer(resource_descriptor)
+        #         output = ct.create_unicode_buffer(1024)
+        #         result = SHLoadIndirectString(inp, output, ct.sizeof(output), None)
+        #         if result == 0 and output.value:
+        #             if not output.value.startswith(RESOURCE_PREFIX):
+        #                 return output.value
+        # except OSError:
+        #     pass
 
-        try:
-            resource_descriptor = "@{{{}\\resources.pri? ms-resource://{}}}".format(install_location,
-                                                                                    resource[len(RESOURCE_PREFIX):])
-            inp = ct.create_unicode_buffer(resource_descriptor)
-            output = ct.create_unicode_buffer(1024)
-            result = SHLoadIndirectString(inp, output, ct.sizeof(output), None)
-            if result == 0 and output.value:
-                if not output.value.startswith(RESOURCE_PREFIX):
-                    return output.value
-        except OSError:
-            pass
+        # try:
+        #     resource_descriptor = "@{{{}\\resources.pri? ms-resource://{}}}".format(install_location,
+        #                                                                             resource[len(RESOURCE_PREFIX):])
+        #     inp = ct.create_unicode_buffer(resource_descriptor)
+        #     output = ct.create_unicode_buffer(1024)
+        #     result = SHLoadIndirectString(inp, output, ct.sizeof(output), None)
+        #     if result == 0 and output.value:
+        #         if not output.value.startswith(RESOURCE_PREFIX):
+        #             return output.value
+        # except OSError:
+        #     pass
 
         return None
 

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -127,12 +127,12 @@ class AppXPackage(object):
     def _get_resource(install_location, package_id, resource):
         """Helper method to resolve resource strings to their (localized) value
         """
-        # testing more compact working resolver
+        # this has resolved every resource I could find with 1 API call.
         try:
             if resource[0:12] == RESOURCE_PREFIX:
                 resource_key = resource[12:]
                 if resource_key.startswith("//"):
-                    resource_path = RESOURCE_PREFIX + resource_key
+                    resource_path = resource
                 elif resource_key.startswith("/"):
                     resource_path = RESOURCE_PREFIX + "//" + resource_key
                 elif resource_key.find('/') != -1:
@@ -150,37 +150,6 @@ class AppXPackage(object):
                         return output.value
         except OSError:
             pass
-
-        # try:
-        #     resource_descriptor = None
-        #     if resource.startswith("ms-resource:/"):
-        #         resource_descriptor = "@{{{}\\resources.pri? {}}}".format(install_location,
-        #                                                                   resource)
-        #     elif resource.startswith(RESOURCE_PREFIX):
-        #         resource_descriptor = "@{{{}\\resources.pri? ms-resource://{}/resources/{}}}".format(install_location,
-        #                                                                                              package_id,
-        #                                                                                              resource[len(RESOURCE_PREFIX):])
-        #     if resource_descriptor:
-        #         inp = ct.create_unicode_buffer(resource_descriptor)
-        #         output = ct.create_unicode_buffer(1024)
-        #         result = SHLoadIndirectString(inp, output, ct.sizeof(output), None)
-        #         if result == 0 and output.value:
-        #             if not output.value.startswith(RESOURCE_PREFIX):
-        #                 return output.value
-        # except OSError:
-        #     pass
-
-        # try:
-        #     resource_descriptor = "@{{{}\\resources.pri? ms-resource://{}}}".format(install_location,
-        #                                                                             resource[len(RESOURCE_PREFIX):])
-        #     inp = ct.create_unicode_buffer(resource_descriptor)
-        #     output = ct.create_unicode_buffer(1024)
-        #     result = SHLoadIndirectString(inp, output, ct.sizeof(output), None)
-        #     if result == 0 and output.value:
-        #         if not output.value.startswith(RESOURCE_PREFIX):
-        #             return output.value
-        # except OSError:
-        #     pass
 
         return None
 

--- a/windowsapps.ini
+++ b/windowsapps.ini
@@ -4,7 +4,14 @@
 
 [main]
 # Defines a custom label for the windows app catalog items
-# Catalog items will be formatted "<item_label> <app_name>" e.g. "Windows App: Music"
+# Catalog items will be formatted "<item_label> <app_name>" e.g. "Windows App: Music" 
+# If the label is set to empty, the leading space will be automatically trimmed)
 #
 # Default: Windows App:
 #item_label = Windows App:
+
+# Some windows apps are not intended for direct use or are supposed to be called indirectly by other apps.
+# These miscellaneous apps apps can clutter the app catalog and are hidden by default.  
+#
+# Default: True
+#hide_misc = true

--- a/windowsapps.ini
+++ b/windowsapps.ini
@@ -4,14 +4,14 @@
 
 [main]
 # Defines a custom label for the windows app catalog items
-# Catalog items will be formatted "<item_label> <app_name>" e.g. "Windows App: Music" 
+# Catalog items will be formatted "<item_label> <app_name>" e.g. "Windows App: Music"
 # If the label is set to empty, the leading space will be automatically trimmed)
 #
 # Default: Windows App:
 #item_label = Windows App:
 
 # Some windows apps are not intended for direct use or are supposed to be called indirectly by other apps.
-# These miscellaneous apps apps can clutter the app catalog and are hidden by default.  
+# These miscellaneous apps apps can clutter the app catalog and are hidden by default.
 #
-# Default: True
-#hide_misc = true
+# Default: False
+#show_misc_apps = False

--- a/windowsapps.py
+++ b/windowsapps.py
@@ -118,13 +118,13 @@ class WindowsApps(kp.Plugin):
         self.info("Cataloged {} items in {:0.1f} seconds".format(len(catalog), elapsed))
 
     async def _create_catalog_item(self, props):
-        pack = helper.AppXPackage(props)
+        package = helper.AppXPackage(props)
         # some packages can be just libraries with no executable application
         # only take packages which have a application
-        apps = await pack.apps()
+        apps = await package.apps()
         catalog_items = []
         if apps:
-            self.dbg(pack.InstallLocation)
+            self.dbg(package.InstallLocation)
             for app in apps:
                 if not app.misc_app or self._show_misc_apps:
                     catalog_items.append(self.create_item(

--- a/windowsapps.py
+++ b/windowsapps.py
@@ -13,7 +13,7 @@ class WindowsApps(kp.Plugin):
     """
 
     DEFAULT_ITEM_LABEL = "Windows App:"
-    DEFAULT_SHOW_MISC = False
+    DEFAULT_SHOW_MISC_APPS = False
 
     def __init__(self):
         """Default constructor and initializing internal attributes
@@ -65,7 +65,7 @@ class WindowsApps(kp.Plugin):
         self._item_label = settings.get("item_label", "main", self.DEFAULT_ITEM_LABEL)
         self.dbg("item_label =", self._item_label)
 
-        self._show_misc = settings.get_bool("show_misc", "main", self.DEFAULT_SHOW_MISC)
+        self._show_misc_apps = settings.get_bool("show_misc_apps", "main", self.DEFAULT_SHOW_MISC_APPS)
 
     def on_start(self):
         """Reads the config
@@ -126,16 +126,16 @@ class WindowsApps(kp.Plugin):
         if apps:
             self.dbg(pack.InstallLocation)
             for app in apps:
-                if (not app.misc) or self._show_misc:
+                if not app.misc_app or self._show_misc_apps:
                     catalog_items.append(self.create_item(
                         category=kp.ItemCategory.CMDLINE,
                         label='{} {}'.format(self._item_label, app.display_name).strip(),
                         short_desc=app.description
-                        if app.description is not None else app.display_name,
+                        if app.description else app.display_name,
                         target=app.execution,
                         args_hint=kp.ItemArgsHint.FORBIDDEN,
                         hit_hint=kp.ItemHitHint.NOARGS,
-                        icon_handle=self._get_icon(app.name, app.icon_path)
+                        icon_handle=self._get_icon(app.app_id, app.icon_path)
                     ))
         return catalog_items
 


### PR DESCRIPTION
Iterating through Apps now checks the `uap:VisualElement` Tag inside the Application Tag and gets app specific display name, description and icon-path from its attributes if possible. Uses the package default if it can't use them. (which seems to primarily used for Microsoft Store Listings). The attribute `AppListEntry` is used to check whether the package developer intended the app to be shown in App Lists.

Apps which should not be shown are ignored during the catalog building by default (added `.ini`
 flag to make it configurable).

A nice package to test this is the `Mail and Calendar` package from Microsoft.

Further small changes I would undo if not wanted:
 * changing ElementTree to cElementTree gave my older notebook a slight performance boost. 
 * changed _get_resource to only use one API call. (I couldn't find any ms-resource my code couldn't resolve
 *  Added some lines to the `.ini` and `readme.md` file and removed some linting errors from the `readme.md ` file 
* added a `.strip()` to the catalog label string to remove leading space if `item_label` has been set to blank.